### PR TITLE
Specify GET method when submitting task for CSV load so that worker doesn't return 405

### DIFF
--- a/views/web.py
+++ b/views/web.py
@@ -327,5 +327,5 @@ def import_employees_form():
 @admin_required
 def import_employees():
     flash('We started importing employee data in the background. Refresh the page to see it.', 'info')
-    taskqueue.add(url='/tasks/employees/load/csv')
+    taskqueue.add(url='/tasks/employees/load/csv', method='GET')
     return redirect(url_for('employees'))


### PR DESCRIPTION
Hello!  I battled with a bit of an issue setting up yelp-love and using the CSV import feature.  Apparently the CSV import submits a task to a queue in the `worker` module, which does the actual import.

The first issue I ran across was that the request for `/tasks/employees/load/csv` did not seem to get routed to the `worker` module.  I addressed that by uploading the `dispatch.yaml` file (I used a command found in #5).

The next issue I encountered (which this PR addresses) is that the task would return 405 Method Not Allowed. Turns out that the task function only allows a GET method, but when the task is submitted, the `taskqueue.add()` function defaults to POST ([docs](https://cloud.google.com/appengine/docs/python/refdocs/google.appengine.api.taskqueue), grep for `default to post`).

The options were either add POST to the list of allowed methods for `load_employees_from_csv`, or specify GET in the task submission. In this PR I decided to specify GET in the task submission, since all of the neighboring tasks in `views/task.py` seemed to be GET only. However, having some methods be GET and some be POST seems like a liability, since there is other code that uses `taskqueue.add` without specifying the method, and it works fine since those tasks use POST (see `logic/love.py` and `logic/event.py`). It may make sense to use POST for all the tasks, if only for the benefit that the next time somebody types `taskqueue.add` they don't need to know which method type their task uses.