### PR TITLE
Use appspotmail.com instead of appspot.com for email sender

### DIFF
--- a/config-example.py
+++ b/config-example.py
@@ -5,7 +5,7 @@ APP_NAME = 'Yelp Love'
 
 APP_BASE_URL = 'https://PROJECT_ID.appspot.com/'
 
-LOVE_SENDER_EMAIL = 'Yelp Love <love@PROJECT_ID.appspot.com>'
+LOVE_SENDER_EMAIL = 'Yelp Love <love@PROJECT_ID.appspotmail.com>'
 
 # Flask's secret key, used to encrypt the session cookie.
 # Set this to any random string and make sure not to share this!


### PR DESCRIPTION
I used the default `appspot.com` email sender and got several exceptions (`InvalidSender` or something). The [documentation](https://cloud.google.com/appengine/docs/python/mail/#Python_Sending_mail) suggests using `.appspotmail.com`, and changing my `config.py` to use that fixed the issue. So I figured that ought to be the default in the example config.