### PR TITLE
Implement Gravatar support behind config variable.

### DIFF
--- a/config-example.py
+++ b/config-example.py
@@ -27,4 +27,4 @@ S3_BUCKET = 'employees'
 # * 'always' - prefers Gravatar over the Employee.photo_url
 # * 'backup' - use Gravatar when photo_url is empty
 # * anything else - disabled
-GRAVATAR = 'always'
+GRAVATAR = 'backup'

--- a/config-example.py
+++ b/config-example.py
@@ -22,3 +22,9 @@ DOMAIN = 'example.com'
 # Name of the S3 bucket used to import employee data from a file named employees.json
 # Check out /import/employees.json.example to see how this file should look like.
 S3_BUCKET = 'employees'
+
+# When do we use Gravatar? Options are:
+# * 'always' - prefers Gravatar over the Employee.photo_url
+# * 'backup' - use Gravatar when photo_url is empty
+# * anything else - disabled
+GRAVATAR = 'always'

--- a/models/employee.py
+++ b/models/employee.py
@@ -82,9 +82,8 @@ class Employee(ndb.Model, Pagination):
 
     def get_gravatar(self):
         """Creates gravatar URL from email address."""
-        email = '{user}@{domain}'.format(user=self.username, domain=config.DOMAIN)
         m = hashlib.md5()
-        m.update(email)
+        m.update(self.user.email())
         encoded_hash = base64.b16encode(m.digest()).lower()
         return '//gravatar.com/avatar/{}?s=200'.format(encoded_hash)
 

--- a/models/employee.py
+++ b/models/employee.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+import base64
+import hashlib
 import functools
 
 from google.appengine.ext import ndb
@@ -77,6 +79,25 @@ class Employee(ndb.Model, Pagination):
         self.photo_url = d.get('photo_url')
         self.department = d.get('department')
         self.meta_department = get_meta_department(self.department)
+
+    def get_gravatar(self):
+        """Creates gravatar URL from email address."""
+        email = '{user}@{domain}'.format(user=self.username, domain=config.DOMAIN)
+        m = hashlib.md5()
+        m.update(email)
+        encoded_hash = base64.b16encode(m.digest()).lower()
+        return '//gravatar.com/avatar/{}?s=200'.format(encoded_hash)
+
+    def get_photo_url(self):
+        """Return an avatar photo URL (depending on Gravatar config). This still could
+        be empty, in which case the theme needs to provide an alternate photo.
+        """
+        if config.GRAVATAR == 'always':
+            return self.get_gravatar()
+        elif config.GRAVATAR == 'backup' and not self.photo_url:
+            return self.get_gravatar()
+        else:
+            return self.photo_url
 
     @property
     def full_name(self):

--- a/testing/factories/employee.py
+++ b/testing/factories/employee.py
@@ -7,12 +7,16 @@ def create_employee(
     department='Engineering',
     first_name='John',
     last_name='Doe',
+    photo_url=None,
 ):
+
+    if photo_url is None:
+        photo_url = 'http://example.com/photos/{0}.jpg'.format(username)
 
     return Employee.create_from_dict({
         'username': username,
         'department': department,
         'first_name': first_name,
         'last_name': last_name,
-        'photo_url': 'http://exmaple.com/photos/{0}.jpg'.format(username),
+        'photo_url': photo_url,
     })

--- a/tests/models/employee_test.py
+++ b/tests/models/employee_test.py
@@ -49,3 +49,27 @@ class EmployeeTest(unittest.TestCase):
     def test_full_name(self):
         employee = create_employee(first_name='Foo', last_name='Bar')
         self.assertEqual('Foo Bar', employee.full_name)
+
+    @mock.patch('models.employee.config')
+    def test_gravatar_backup(self, mock_config):
+        mock_config.GRAVATAR = 'backup'
+        employee = create_employee(photo_url='')
+        self.assertEqual(employee.get_gravatar(), employee.get_photo_url())
+        employee = create_employee(photo_url='http://example.com/example.jpg')
+        self.assertEqual(employee.photo_url, employee.get_photo_url())
+
+    @mock.patch('models.employee.config')
+    def test_gravatar_always(self, mock_config):
+        mock_config.GRAVATAR = 'always'
+        employee = create_employee(photo_url='')
+        self.assertEqual(employee.get_gravatar(), employee.get_photo_url())
+        employee = create_employee(photo_url='http://example.com/example.jpg')
+        self.assertEqual(employee.get_gravatar(), employee.get_photo_url())
+
+    @mock.patch('models.employee.config')
+    def test_gravatar_disabled(self, mock_config):
+        mock_config.GRAVATAR = 'disabled'
+        employee = create_employee(photo_url='')
+        self.assertEqual(employee.photo_url, employee.get_photo_url())
+        employee = create_employee(photo_url='http://example.com/example.jpg')
+        self.assertEqual(employee.photo_url, employee.get_photo_url())

--- a/themes/default/templates/parts/avatar.html
+++ b/themes/default/templates/parts/avatar.html
@@ -1,6 +1,6 @@
 {% macro avatar_url_for(employee) -%}
-    {% if employee.photo_url -%}
-        {{ employee.photo_url }}
+    {% if employee.get_photo_url() -%}
+        {{ employee.get_photo_url() }}
     {%- else -%}
         {{ theme_static('img/user_medium_square.png', external=True) }}
     {%- endif %}


### PR DESCRIPTION
This branch allows you to set a config variable based on how you would like to use Gravatars. Your options are:

- `always`: Gravatars are used in place of whatever photo is provided in the Employee `photo_url` field.
- `backup`: Gravatars are used whenever an Employee has a blank `photo_url` field.
- anything else: gravatars are disabled (at which point the theme provides a sane default)