### PR TITLE
Explicit protocol in gravatar links

### DIFF
--- a/models/employee.py
+++ b/models/employee.py
@@ -85,7 +85,7 @@ class Employee(ndb.Model, Pagination):
         m = hashlib.md5()
         m.update(self.user.email())
         encoded_hash = base64.b16encode(m.digest()).lower()
-        return '//gravatar.com/avatar/{}?s=200'.format(encoded_hash)
+        return 'https://gravatar.com/avatar/{}?s=200'.format(encoded_hash)
 
     def get_photo_url(self):
         """Return an avatar photo URL (depending on Gravatar config). This still could


### PR DESCRIPTION
Although // links are better normally, it appears that within email bodies, they
are not processed like they would be in a web browser context. As a result, any
user with a Gravatar will not have their picture show up in emails. This commit
explicitly uses HTTPS so that Gravatars show up in emails.