### PR TITLE
Support sendgrid for email

### DIFF
--- a/config-example.py
+++ b/config-example.py
@@ -9,6 +9,11 @@ LOVE_SENDER_EMAIL = 'Yelp Love <love@PROJECT_ID.appspotmail.com>'
 
 # We can use the 'appengine' email API or the 'sendgrid' API. Pick one here.
 EMAIL_BACKEND = 'appengine'
+# If you have EMAIL_BACKEND = 'sendgrid', you'll need to set the SENDGRID_API_KEY
+# secret using the Secret Model. This is documented in the README in the discussion
+# on "JSON via Amazon S3". You'll also need to add the sendgrid module to your
+# requirements.txt. Note that you don't need it in your requirements if you don't
+# have it chosen!
 
 # Flask's secret key, used to encrypt the session cookie.
 # Set this to any random string and make sure not to share this!

--- a/config-example.py
+++ b/config-example.py
@@ -7,6 +7,9 @@ APP_BASE_URL = 'https://PROJECT_ID.appspot.com/'
 
 LOVE_SENDER_EMAIL = 'Yelp Love <love@PROJECT_ID.appspotmail.com>'
 
+# We can use the 'appengine' email API or the 'sendgrid' API. Pick one here.
+EMAIL_BACKEND = 'appengine'
+
 # Flask's secret key, used to encrypt the session cookie.
 # Set this to any random string and make sure not to share this!
 SECRET_KEY = 'YOUR_SECRET_HERE'

--- a/logic/email.py
+++ b/logic/email.py
@@ -1,8 +1,7 @@
 # -*- coding: utf-8 -*-
-import re
-
 from google.appengine.api.mail import EmailMessage
 
+from util.email import get_name_and_email
 import config
 import logic.secret
 
@@ -10,17 +9,6 @@ if config.EMAIL_BACKEND == 'sendgrid':
     # a bit of a hack here so that we can avoid adding dependencies unless
     # the user wants them
     import sendgrid
-
-
-def get_name_and_email(email_string):
-    """Take a string that is either 'Name <email>' or just an email address
-    and return a two tuple (email, name). If there is just an email, returns
-    None for the name."""
-    match = re.match(r'(.*) <(.*)>', email_string)
-    if match:
-        return match.group(2), match.group(1)
-    else:
-        return email_string, None
 
 
 def send_appengine_email(sender, recipient, subject, body_html, body_text):

--- a/logic/email.py
+++ b/logic/email.py
@@ -1,7 +1,26 @@
 # -*- coding: utf-8 -*-
+import re
+
 from google.appengine.api.mail import EmailMessage
 
 import config
+import logic.secret
+
+if config.EMAIL_BACKEND == 'sendgrid':
+    # a bit of a hack here so that we can avoid adding dependencies unless
+    # the user wants them
+    import sendgrid
+
+
+def get_name_and_email(email_string):
+    """Take a string that is either 'Name <email>' or just an email address
+    and return a two tuple (email, name). If there is just an email, returns
+    None for the name."""
+    match = re.match(r'(.*) <(.*)>', email_string)
+    if match:
+        return match.group(2), match.group(1)
+    else:
+        return email_string, None
 
 
 def send_appengine_email(sender, recipient, subject, body_html, body_text):
@@ -14,12 +33,34 @@ def send_appengine_email(sender, recipient, subject, body_html, body_text):
     email.send()
 
 
+def send_sendgrid_email(sender, recipient, subject, body_html, body_text):
+    key = logic.secret.get_secret('SENDGRID_API_KEY')
+    sg = sendgrid.SendGridAPIClient(apikey=key)
+
+    from_ = sendgrid.helpers.mail.Email(*get_name_and_email(sender))
+    to = sendgrid.helpers.mail.Email(*get_name_and_email(recipient))
+    content_html = sendgrid.helpers.mail.Content('text/html', body_html)
+    content_text = sendgrid.helpers.mail.Content('text/plain', body_text)
+    # text/plain needs to be before text/html or sendgrid gets mad
+    message = sendgrid.helpers.mail.Mail(from_, subject, to, content_text)
+    message.add_content(content_html)
+
+    sg.client.mail.send.post(request_body=message.get())
+
+
 EMAIL_BACKENDS = {
     'appengine': send_appengine_email,
+    'sendgrid': send_sendgrid_email,
 }
 
 
 def send_email(sender, recipient, subject, body_html, body_text):
-    """Send an email notifying the recipient of l about their love."""
+    """Send an email using whatever configured backend there is.
+    sender, recipient - email address, can be bare, or in the
+        Name <address@example.com> format
+    subject - string
+    body_html - string
+    body_text - string
+    """
     backend = EMAIL_BACKENDS[config.EMAIL_BACKEND]
     backend(sender, recipient, subject, body_html, body_text)

--- a/logic/email.py
+++ b/logic/email.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+from google.appengine.api.mail import EmailMessage
+
+import config
+
+
+def send_appengine_email(sender, recipient, subject, body_html, body_text):
+    email = EmailMessage()
+    email.sender = sender
+    email.to = recipient
+    email.subject = subject
+    email.body = body_text
+    email.html = body_html
+    email.send()
+
+
+EMAIL_BACKENDS = {
+    'appengine': send_appengine_email,
+}
+
+
+def send_email(sender, recipient, subject, body_html, body_text):
+    """Send an email notifying the recipient of l about their love."""
+    backend = EMAIL_BACKENDS[config.EMAIL_BACKEND]
+    backend(sender, recipient, subject, body_html, body_text)

--- a/logic/love.py
+++ b/logic/love.py
@@ -67,12 +67,12 @@ def send_love_email(l):
     to = recipient.user.email()
     subject = u'Love from {}'.format(sender.full_name)
 
-    body = u'"{}"\n\n{}'.format(
+    body_text = u'"{}"\n\n{}'.format(
         l.message,
         '(Sent secretly)' if l.secret else ''
     )
 
-    html = render_template(
+    body_html = render_template(
         'email.html',
         love=l,
         sender=sender,
@@ -80,7 +80,7 @@ def send_love_email(l):
         recent_love_and_lovers=[(love, love.sender_key.get()) for love in recent_love[:3]]
     )
 
-    logic.email.send_email(from_, to, subject, html, body)
+    logic.email.send_email(from_, to, subject, body_html, body_text)
 
 
 def get_love(sender_username=None, recipient_username=None, limit=None):

--- a/tests/logic/email_test.py
+++ b/tests/logic/email_test.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+import mock
+import unittest
+
+import logic.email
+
+
+class EmailTest(unittest.TestCase):
+    """We really just want to test that configuration is honored here."""
+
+    sender = 'test@example.com'
+    recipient = 'test@example.com'
+    subject = 'test subject'
+    html = '<p>hello test</p>'
+    text = 'hello test'
+
+    @mock.patch('logic.email.EMAIL_BACKENDS')
+    @mock.patch('logic.email.config')
+    def test_send_email_appengine(self, mock_config, mock_backends):
+        mock_config.EMAIL_BACKEND = 'appengine'
+        mock_backends['appengine'] = mock.Mock()
+        logic.email.send_email(self.sender, self.recipient, self.subject,
+                               self.html, self.text)
+        mock_backends['appengine'].assert_called_once_with(
+            self.sender, self.recipient, self.subject, self.html, self.text
+        )
+
+    @mock.patch('logic.email.EMAIL_BACKENDS')
+    @mock.patch('logic.email.config')
+    def test_send_email_sendgrid(self, mock_config, mock_backends):
+        mock_config.EMAIL_BACKEND = 'sendgrid'
+        mock_backends['sendgrid'] = mock.Mock()
+        logic.email.send_email(self.sender, self.recipient, self.subject,
+                               self.html, self.text)
+        mock_backends['sendgrid'].assert_called_once_with(
+            self.sender, self.recipient, self.subject, self.html, self.text
+        )

--- a/tests/util/email_test.py
+++ b/tests/util/email_test.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+import unittest
+
+import util.email
+
+
+class GetNameAndEmailTest(unittest.TestCase):
+    """Tests util.email.get_name_and_email()"""
+
+    def test_bare_email(self):
+        email_string = 'darwin@example.com'
+        email, name = util.email.get_name_and_email(email_string)
+        self.assertEqual(email, email_string)
+        self.assertIsNone(name)
+
+    def test_name_and_email(self):
+        email_string = 'Darwin Stoppelman <darwin@example.com>'
+        email, name = util.email.get_name_and_email(email_string)
+        self.assertEqual(email, 'darwin@example.com')
+        self.assertEqual(name, 'Darwin Stoppelman')

--- a/tests/views/task_test.py
+++ b/tests/views/task_test.py
@@ -22,7 +22,7 @@ class EmailLoveTestCase(LoggedInAdminBaseTest):
         self.recipient.key.delete()
         self.sender.key.delete()
 
-    @mock.patch('logic.love.send_email', autospec=True)
+    @mock.patch('logic.love.send_love_email', autospec=True)
     def test_send_love_email(self, mock_send_email):  # noqa
         response = self.app.post(
             '/tasks/love/email',

--- a/util/email.py
+++ b/util/email.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+import re
+
+
+def get_name_and_email(email_string):
+    """Take a string that is either 'Name <email>' or just an email address
+    and return a two tuple (email, name). If there is just an email, returns
+    None for the name."""
+    match = re.match(r'(.*) <(.*)>', email_string)
+    if match:
+        return match.group(2), match.group(1)
+    else:
+        return email_string, None

--- a/views/tasks.py
+++ b/views/tasks.py
@@ -50,7 +50,7 @@ def rebuild_index():
 def email_love():
     love_id = int(request.form['id'])
     love = ndb.Key(Love, love_id).get()
-    logic.love.send_email(love)
+    logic.love.send_love_email(love)
     return Response(status=200)
 
 


### PR DESCRIPTION
As discussed in [hacsoc#6](https://github.com/hacsoc/love/issues/6), this pull request does:
- move email sending into `logic/email.py`
- establish a system for supporting multiple email sending backends
- add support for SendGrid email API
  - use Secret model for storage of API key
  - no need to add sendgrid clientlib to `requirements.txt` if you do not have it enabled in your `config.py`
- test that the configuration switch works as expected

The sendgrid support is tested in dev and prod on the CWRU Love instance :)