### PR TITLE
Silent remove self in group

### DIFF
--- a/logic/love.py
+++ b/logic/love.py
@@ -139,12 +139,17 @@ def send_loves(recipients, message, sender_username=None, secret=False):
     if len(recipients) != len(unique_recipients):
         raise TaintedLove(u'Sorry, you are trying to send love to a user multiple times.')
 
+    # Only raise an error if the only recipient is the sender.
+    if sender_username in unique_recipients:
+        unique_recipients.remove(sender_username)
+        if len(unique_recipients) == 0:
+            raise TaintedLove(u'You can love yourself, but not on {}!'.format(
+                config.APP_NAME
+            ))
+
     # validate all recipients before carrying out any Love transactions
     recipient_keys = []
     for recipient_username in unique_recipients:
-        if sender_username == recipient_username:
-            raise TaintedLove(u'You can love yourself, but not on {}!'.format(config.APP_NAME))
-
         recipient_key = Employee.query(
             Employee.username == recipient_username,
             Employee.terminated == False

--- a/logic/love.py
+++ b/logic/love.py
@@ -163,6 +163,8 @@ def send_loves(recipients, message, sender_username=None, secret=False):
     for recipient_key in recipient_keys:
         _send_love(recipient_key, message, sender_key, secret)
 
+    return unique_recipients
+
 
 def _send_love(recipient_key, message, sender_key, secret):
     """Send love and do associated bookkeeping."""

--- a/tests/logic/love_test.py
+++ b/tests/logic/love_test.py
@@ -43,16 +43,24 @@ class SendLovesTest(unittest.TestCase):
                 sender_username='wwu',
             )
 
-    def test_sender_is_recipient(self):
-        with self.assertRaises(TaintedLove):
-            logic.love.send_loves(
-                set(['bob', 'alice']),
-                'hallo',
-                sender_username='alice',
-            )
+    def test_sender_is_a_recipient(self):
+        logic.love.send_loves(
+            set(['bob', 'alice']),
+            self.message,
+            sender_username='alice',
+        )
 
         loves_for_bob = logic.love.get_love('alice', 'bob').get_result()
-        self.assertEqual(loves_for_bob, [])
+        self.assertEqual(len(loves_for_bob), 1)
+        self.assertEqual(loves_for_bob[0].message, self.message)
+
+    def test_sender_is_only_recipient(self):
+        with self.assertRaises(TaintedLove):
+            logic.love.send_loves(
+                set(['alice']),
+                self.message,
+                sender_username='alice',
+            )
 
     def test_invalid_recipient(self):
         with self.assertRaises(TaintedLove):

--- a/views/api.py
+++ b/views/api.py
@@ -66,7 +66,7 @@ def api_send_loves():
     message = request.form.get('message')
 
     try:
-        send_loves(recipients, message, sender_username=sender)
+        recipients = send_loves(recipients, message, sender_username=sender)
         recipients_display_str = ', '.join(recipients)
         return make_response(
             u'Love sent to {}!'.format(recipients_display_str),

--- a/views/web.py
+++ b/views/web.py
@@ -212,9 +212,11 @@ def love():
         return redirect(url_for('home', recipients=recipients_display_str))
 
     try:
-        logic.love.send_loves(recipients, message, secret=secret)
+        real_recipients = logic.love.send_loves(recipients, message, secret=secret)
+        # actual recipients may have the sender stripped from the list
+        real_display_str = ', '.join(real_recipients)
 
-        flash('{}ove sent to {}!'.format('Secret l' if secret else 'L', recipients_display_str))
+        flash('{}ove sent to {}!'.format('Secret l' if secret else 'L', real_display_str))
         return redirect(url_for('home'))
     except TaintedLove as exc:
         if exc.is_error:


### PR DESCRIPTION
This implements #30, if the consensus is that it's a good idea (I think it is). The `logic.love.send_loves` function is modified to only raise an error when the sender is the *only* recipient, rather than *any* of the recipients. It is further modified to return the list of usernames that it actually sent to.

The `web` and `api` views are modified to only report those usernames. This way if you are Alice and you're sending to Alice and Bob, you'll see the message "Love sent to Bob" rather than "Love sent to Alice, Bob".