### PR TITLE
Focus on the textbox on the explore page

### DIFF
--- a/themes/default/templates/explore.html
+++ b/themes/default/templates/explore.html
@@ -91,6 +91,7 @@
   <script type="text/javascript">
     $(document).ready(function() {
       $('#nav-explore').addClass('active');
+      $('input[name="user"]').focus();
       $('#explore-username').autocomplete({
         source: '/user/autocomplete',
         minLength: 2,


### PR DESCRIPTION
When you click on the explore page, I think it would be more convenient if you didnt have to click on the input box.