### PR TITLE
Upgrade GAE to 1.9.63 and use repo-local GAE installation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,19 +2,19 @@
 
 all: test
 
-run-dev: config.py lib
-	dev_appserver.py dispatch.yaml app.yaml worker.yaml
+run-dev: config.py lib google_appengine
+	google_appengine/dev_appserver.py dispatch.yaml app.yaml worker.yaml
 
-deploy: deploy_build
+deploy: deploy_build google_appengine
 	# If you are running into permission issues and see a message like this:
 	# You do not have permission to modify this app (app_id=u'foobar').
 	# then try adding --no_cookies to the commands below
-	appcfg.py update app.yaml worker.yaml
-	appcfg.py update_dispatch .
-	appcfg.py update_queues .
-	appcfg.py update_indexes .
+	google_appengine/appcfg.py update app.yaml worker.yaml
+	google_appengine/appcfg.py update_dispatch .
+	google_appengine/appcfg.py update_queues .
+	google_appengine/appcfg.py update_indexes .
 	# If you are using cron.yaml uncomment the line below
-	# appcfg.py update_cron .
+	# google_appengine/appcfg.py update_cron .
 
 deploy_build: config.py clean lib test
 	@echo "\033[31mHave you bumped the app version? Hit ENTER to continue, CTRL-C to abort.\033[0m"

--- a/Makefile
+++ b/Makefile
@@ -37,8 +37,8 @@ clean:
 
 google_appengine:
 	mkdir -p tmp
-	wget -O tmp/google_appengine.zip 'https://storage.googleapis.com/appengine-sdks/featured/google_appengine_1.9.40.zip' --no-check-certificate
-	echo 'f88b532ae7e23ab88290e939882a61140cb2a82a  tmp/google_appengine.zip' | shasum --check -
+	wget -O tmp/google_appengine.zip 'https://storage.googleapis.com/appengine-sdks/featured/google_appengine_1.9.63.zip' --no-check-certificate
+	echo '1ecce0c6f192bd0e02649dfa9dd07e124c9eaaee  tmp/google_appengine.zip' | shasum --check -
 	unzip tmp/google_appengine.zip
 
 venv:

--- a/Makefile
+++ b/Makefile
@@ -20,10 +20,10 @@ deploy_build: config.py clean lib test
 	@echo "\033[31mHave you bumped the app version? Hit ENTER to continue, CTRL-C to abort.\033[0m"
 	@read ignored
 
-lib: requirements.txt
+lib: requirements.txt venv
 	mkdir -p lib
 	rm -rf lib/*
-	pip install -r requirements.txt -t lib
+	venv/bin/pip install -r requirements.txt -t lib
 
 test: google_appengine
 	# reset database before each test run
@@ -39,3 +39,6 @@ google_appengine:
 	mkdir -p tmp
 	wget -O tmp/google_appengine.zip 'https://storage.googleapis.com/appengine-sdks/featured/google_appengine_1.9.40.zip' --no-check-certificate
 	unzip tmp/google_appengine.zip
+
+venv:
+	virtualenv -p python2.7 $@

--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,7 @@ clean:
 google_appengine:
 	mkdir -p tmp
 	wget -O tmp/google_appengine.zip 'https://storage.googleapis.com/appengine-sdks/featured/google_appengine_1.9.40.zip' --no-check-certificate
+	echo 'f88b532ae7e23ab88290e939882a61140cb2a82a  tmp/google_appengine.zip' | shasum --check -
 	unzip tmp/google_appengine.zip
 
 venv:


### PR DESCRIPTION
I've pulled together a few small changes into this one branch based on some recent challenges I had getting a local run to work.

* Upgrade to the latest version of GAE.
* Perform SHA checksum against downloaded files, just in case.
* Use a locally downloaded version of GAE instead of whatever is running on the dev's machine.
* Not every machine has pip installed in the `PATH`, so this creates a virtualenv to do the build.
