### PR TITLE
Revert "Upgrade GAE to 1.9.63 and use repo-local GAE installation"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,28 +2,28 @@
 
 all: test
 
-run-dev: config.py lib google_appengine
-	google_appengine/dev_appserver.py dispatch.yaml app.yaml worker.yaml
+run-dev: config.py lib
+	dev_appserver.py dispatch.yaml app.yaml worker.yaml
 
-deploy: deploy_build google_appengine
+deploy: deploy_build
 	# If you are running into permission issues and see a message like this:
 	# You do not have permission to modify this app (app_id=u'foobar').
 	# then try adding --no_cookies to the commands below
-	google_appengine/appcfg.py update app.yaml worker.yaml
-	google_appengine/appcfg.py update_dispatch .
-	google_appengine/appcfg.py update_queues .
-	google_appengine/appcfg.py update_indexes .
+	appcfg.py update app.yaml worker.yaml
+	appcfg.py update_dispatch .
+	appcfg.py update_queues .
+	appcfg.py update_indexes .
 	# If you are using cron.yaml uncomment the line below
-	# google_appengine/appcfg.py update_cron .
+	# appcfg.py update_cron .
 
 deploy_build: config.py clean lib test
 	@echo "\033[31mHave you bumped the app version? Hit ENTER to continue, CTRL-C to abort.\033[0m"
 	@read ignored
 
-lib: requirements.txt venv
+lib: requirements.txt
 	mkdir -p lib
 	rm -rf lib/*
-	venv/bin/pip install -r requirements.txt -t lib
+	pip install -r requirements.txt -t lib
 
 test: google_appengine
 	# reset database before each test run
@@ -37,9 +37,5 @@ clean:
 
 google_appengine:
 	mkdir -p tmp
-	wget -O tmp/google_appengine.zip 'https://storage.googleapis.com/appengine-sdks/featured/google_appengine_1.9.63.zip' --no-check-certificate
-	echo '1ecce0c6f192bd0e02649dfa9dd07e124c9eaaee  tmp/google_appengine.zip' | shasum --check -
+	wget -O tmp/google_appengine.zip 'https://storage.googleapis.com/appengine-sdks/featured/google_appengine_1.9.40.zip' --no-check-certificate
 	unzip tmp/google_appengine.zip
-
-venv:
-	virtualenv -p python2.7 $@


### PR DESCRIPTION
Reverts Yelp/love#40

Hi @mesozoic,

running `make run-dev` fails with

(venv) ➜  yelplove git:(master) make run-dev
google_appengine/dev_appserver.py dispatch.yaml app.yaml worker.yaml
INFO     2017-11-17 11:11:54,217 sdk_update_checker.py:229] Checking for updates to the SDK.
INFO     2017-11-17 11:12:01,198 api_server.py:205] Starting API server at: http://localhost:59792
INFO     2017-11-17 11:12:01,199 dispatcher.py:185] Starting dispatcher running at: http://localhost:8080
INFO     2017-11-17 11:12:01,203 dispatcher.py:197] Starting module "default" running at: http://localhost:8081
INFO     2017-11-17 11:12:01,208 dispatcher.py:197] Starting module "worker" running at: http://localhost:8082
INFO     2017-11-17 11:12:01,211 admin_server.py:116] Starting admin server at: http://localhost:8000
Traceback (most recent call last):
  File "/Users/svens/Projekte/yelp/yelplove/google_appengine/_python_runtime.py", line 89, in <module>
    _run_file(__file__, globals())
  File "/Users/svens/Projekte/yelp/yelplove/google_appengine/_python_runtime.py", line 85, in _run_file
    execfile(_PATHS.script_file(script_name), globals_)
  File "/Users/svens/Projekte/yelp/yelplove/google_appengine/google/appengine/tools/devappserver2/python/runtime.py", line 179, in <module>
    main()
  File "/Users/svens/Projekte/yelp/yelplove/google_appengine/google/appengine/tools/devappserver2/python/runtime.py", line 159, in main
    sandbox.enable_sandbox(config)
  File "/Users/svens/Projekte/yelp/yelplove/google_appengine/google/appengine/tools/devappserver2/python/sandbox.py", line 197, in enable_sandbox
    __import__('%s.threading' % dist27.__name__)
  File "/Users/svens/Projekte/yelp/yelplove/google_appengine/google/appengine/tools/devappserver2/python/sandbox.py", line 999, in load_module
    raise ImportError('No module named %s' % fullname)
ImportError: No module named google.appengine.dist27.threading
/Users/svens/Projekte/yelp/yelplove/google_appengine/google/appengine/tools/devappserver2/mtime_file_watcher.py:115: UserWarning: There are too many files in your application for changes in all of them to be monitored. You may have to restart the development server to see some changes to your files.
  'There are too many files in your application for '
Traceback (most recent call last):
  File "/Users/svens/Projekte/yelp/yelplove/google_appengine/_python_runtime.py", line 89, in <module>
    _run_file(__file__, globals())
  File "/Users/svens/Projekte/yelp/yelplove/google_appengine/_python_runtime.py", line 85, in _run_file
    execfile(_PATHS.script_file(script_name), globals_)
  File "/Users/svens/Projekte/yelp/yelplove/google_appengine/google/appengine/tools/devappserver2/python/runtime.py", line 179, in <module>
    main()
  File "/Users/svens/Projekte/yelp/yelplove/google_appengine/google/appengine/tools/devappserver2/python/runtime.py", line 159, in main
    sandbox.enable_sandbox(config)
  File "/Users/svens/Projekte/yelp/yelplove/google_appengine/google/appengine/tools/devappserver2/python/sandbox.py", line 197, in enable_sandbox
    __import__('%s.threading' % dist27.__name__)
  File "/Users/svens/Projekte/yelp/yelplove/google_appengine/google/appengine/tools/devappserver2/python/sandbox.py", line 999, in load_module
    raise ImportError('No module named %s' % fullname)
ImportError: No module named google.appengine.dist27.threading