### PR TITLE
Handle the case that some of the users within a love link are unknown

### DIFF
--- a/themes/default/templates/love_link.html
+++ b/themes/default/templates/love_link.html
@@ -25,7 +25,7 @@
         <button type="submit" class="btn btn-lg btn-default">Send Love</button>
         <div class="checkbox">
           <label>
-            <input name="secret" type="checkbox" value="true"> Send in secret <span id="secret-love-label" data-placement="right" data-toggle="tooltip" class="small" title="Your recipient will see this love, but it will not be public to others.">(?)</a>
+            <input name="secret" type="checkbox" value="true"> Send in secret <span id="secret-love-label" data-placement="right" data-toggle="tooltip" class="small" title="Your recipient will see this love, but it will not be public to others.">(?)</span>
           </label>
         </div>
         <input name="link_id" type="hidden" value="{{ link_id }}">

--- a/views/web.py
+++ b/views/web.py
@@ -110,7 +110,7 @@ def love_link(link_id):
             loved=loved,
             link_id=link_id,
         )
-    except NoSuchLoveLink:
+    except NoSuchLoveLink, NoSuchEmployee:
         flash('Sorry, that link ({}) is no longer valid.'.format(link_id), 'error')
         return redirect(url_for('home'))
 

--- a/views/web.py
+++ b/views/web.py
@@ -110,7 +110,7 @@ def love_link(link_id):
             loved=loved,
             link_id=link_id,
         )
-    except NoSuchLoveLink, NoSuchEmployee:
+    except (NoSuchLoveLink, NoSuchEmployee):
         flash('Sorry, that link ({}) is no longer valid.'.format(link_id), 'error')
         return redirect(url_for('home'))
 


### PR DESCRIPTION
This is tracked internally as LOVE-155. At first I tried filtering out the unknown users, but that felt hacky, plus it hid the fact that these users were included originally.

With this change the love links won't be usable still, but at least we show an error message instead of a 500.