### PR TITLE
Enable the console as well as more verbose logging for development

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 all: test
 
 run-dev: config.py lib
-	dev_appserver.py dispatch.yaml app.yaml worker.yaml
+	dev_appserver.py --enable_console true --dev_appserver_log_level debug dispatch.yaml app.yaml worker.yaml
 
 deploy: deploy_build
 	# If you are running into permission issues and see a message like this:


### PR DESCRIPTION
The console used to be enabled by default but isn't anymore. The debug log level does make the output more verbose, but it was the only way I was able to get stacktraces for errors. It works for both web requests as well as cron jobs, which makes development much easier.