### PR TITLE
Rename module to service, since the App Engine terminology changed

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ You will absolutely want to bump the version in [setup.py](setup.py) and
 setup.py and 1-3-10 in app.yaml.
 
 If you modified [worker.yaml](worker.yaml) then you will also need to bump the
-version of worker.yaml. This version number is specific to the worker module and
+version of worker.yaml. This version number is specific to the worker service and
 is independent of the main app version.
 
 When you bumped versions in the appropriate files you can deploy your changes by running

--- a/app.yaml
+++ b/app.yaml
@@ -1,5 +1,5 @@
 application: yelplove
-module: default
+service: default
 version: 1-0-0
 runtime: python27
 api_version: 1

--- a/dispatch.yaml
+++ b/dispatch.yaml
@@ -1,3 +1,3 @@
 dispatch:
   - url: "*/tasks*"
-    module: worker
+    service: worker

--- a/logic/employee.py
+++ b/logic/employee.py
@@ -4,8 +4,6 @@ import json
 import os.path
 import logging
 
-from boto import connect_s3
-from boto.s3.key import Key
 from google.appengine.api import search
 from google.appengine.ext import ndb
 
@@ -86,6 +84,9 @@ def _generate_substrings(string):
 
 
 def _get_employee_info_from_s3():
+    from boto import connect_s3
+    from boto.s3.key import Key
+
     logging.info('Reading employees file from S3...')
     key = Key(
         connect_s3(

--- a/main.py
+++ b/main.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 # flake8: noqa
-import views
 from flask import Flask
 from flask_themes2 import Themes
 
@@ -24,3 +23,6 @@ try:
     app.debug = config.DEBUG
 except AttributeError:
     app.debug = False
+
+# This import needs to stay down here, otherwise we'll get ImportErrors when running tests
+import views  # noqa

--- a/main.py
+++ b/main.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 # flake8: noqa
+import views
 from flask import Flask
 from flask_themes2 import Themes
 
@@ -23,5 +24,3 @@ try:
     app.debug = config.DEBUG
 except AttributeError:
     app.debug = False
-
-import views

--- a/worker.yaml
+++ b/worker.yaml
@@ -1,5 +1,5 @@
 application: yelplove
-module: worker
+service: worker
 version: 1-0-0
 runtime: python27
 api_version: 1


### PR DESCRIPTION
Check out the notice at the top of this [documentation page](https://cloud.google.com/appengine/docs/standard/python/modules/converting).