### PR TITLE
increase leaderboard dept filter performance by storing the departmen…

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -46,6 +46,20 @@ indexes:
 
 - kind: LoveCount
   properties:
+  - name: department
+  - name: week_start
+  - name: sent_count
+    direction: desc
+
+- kind: LoveCount
+  properties:
+  - name: meta_department
+  - name: week_start
+  - name: sent_count
+    direction: desc
+
+- kind: LoveCount
+  properties:
   - name: week_start
   - name: sent_count
     direction: desc

--- a/logic/employee.py
+++ b/logic/employee.py
@@ -9,7 +9,7 @@ from google.appengine.ext import ndb
 
 import config
 from errors import NoSuchEmployee
-from logic import chunk
+from logic import chunk, love_count
 from logic.secret import get_secret
 from logic.toggle import set_toggle_state
 from models import Employee
@@ -172,6 +172,8 @@ def _update_employees(employee_dicts):
         employee.terminated = True
         terminated_employees.append(employee)
     ndb.put_multi(terminated_employees)
+    # we need to rebuild the love count index as the departments may have changed.
+    love_count.rebuild_love_count()
 
     logging.info('Done.')
 

--- a/logic/love_count.py
+++ b/logic/love_count.py
@@ -14,7 +14,11 @@ def top_lovers_and_lovees(utc_week_start, dept=None, limit=20):
     (employee key, received love count), each sorted in descending order of love sent
     or received.
     """
-    sent = LoveCount.query(LoveCount.week_start == utc_week_start).order(-LoveCount.sent_count).fetch()
+    sent_query = LoveCount.query(LoveCount.week_start == utc_week_start)
+    if dept:
+        sent_query = sent_query.filter(ndb.OR(LoveCount.meta_department == dept, LoveCount.department == dept))
+
+    sent = sent_query.order(-LoveCount.sent_count).fetch()
     lovers = []
     for c in sent:
         if len(lovers) == limit:
@@ -22,12 +26,7 @@ def top_lovers_and_lovees(utc_week_start, dept=None, limit=20):
         if c.sent_count == 0:
             continue
         employee_key = c.key.parent()
-        if dept:
-            employee = employee_key.get()
-            if employee.meta_department == dept or employee.department == dept:
-                lovers.append((employee_key, c.sent_count))
-        else:
-            lovers.append((employee_key, c.sent_count))
+        lovers.append((employee_key, c.sent_count))
 
     received = sorted(sent, key=lambda c: c.received_count, reverse=True)
     lovees = []
@@ -37,12 +36,7 @@ def top_lovers_and_lovees(utc_week_start, dept=None, limit=20):
         if c.received_count == 0:
             continue
         employee_key = c.key.parent()
-        if dept:
-            employee = employee_key.get()
-            if employee.meta_department == dept or employee.department == dept:
-                lovees.append((employee_key, c.received_count))
-        else:
-            lovees.append((employee_key, c.received_count))
+        lovees.append((employee_key, c.received_count))
 
     return (lovers, lovees)
 

--- a/models/love_count.py
+++ b/models/love_count.py
@@ -8,6 +8,8 @@ class LoveCount(ndb.Model):
     received_count = ndb.IntegerProperty(default=0)
     sent_count = ndb.IntegerProperty(default=0)
     week_start = ndb.DateTimeProperty()
+    meta_department = ndb.StringProperty()
+    department = ndb.StringProperty()
 
     @classmethod
     def update(cls, love):
@@ -20,10 +22,13 @@ class LoveCount(ndb.Model):
         if sender_count is not None:
             sender_count.sent_count += 1
         else:
+            employee = love.sender_key.get()
             sender_count = cls(
                 parent=love.sender_key,
                 sent_count=1,
-                week_start=utc_week_start
+                week_start=utc_week_start,
+                department=employee.department,
+                meta_department=employee.meta_department,
             )
         sender_count.put()
 
@@ -34,10 +39,13 @@ class LoveCount(ndb.Model):
         if recipient_count is not None:
             recipient_count.received_count += 1
         else:
+            employee = love.recipient_key.get()
             recipient_count = cls(
                 parent=love.recipient_key,
                 received_count=1,
-                week_start=utc_week_start
+                week_start=utc_week_start,
+                department=employee.department,
+                meta_department=employee.meta_department,
             )
         recipient_count.put()
 


### PR DESCRIPTION
…t in the love_count table.

This allows use to directly filter on the department instead of getting all records and the getting the employee each time and do an inmemory check.

/cc @sjaensch 