### PR TITLE
Use Helvetica Neue by default, add Arial, bump urllib3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,6 @@ itsdangerous==0.24
 Jinja2==2.9.5
 MarkupSafe==1.0
 pytz==2016.10
-urllib3==1.20
+urllib3==1.24.3
 Werkzeug==0.12
 wheel==0.29.0

--- a/themes/default/static/css/style.css
+++ b/themes/default/static/css/style.css
@@ -3,7 +3,7 @@ body {
 }
 
 body,h1,h2,h3,h4,h5,h6,.h1,.h2,.h3,.h4,.h5,.h6,.navbar,.btn {
-    font-family: "Helvetica","Helvetica Neue","sans-serif" ;
+    font-family: "Helvetica Neue",Helvetica,Arial,sans-serif;
 }
 
 h2 {


### PR DESCRIPTION
The only piece of internal feedback regarded the usage of Helvetica Neue, and the addition of Arial for Windows users.

I'm also bumping urllib3 to the highest version below 1.25.0, since during `make lib` pip was complaining that requests wanted a urllib3 version >=1.21 and <1.25, while we were installing 1.20.