### PR TITLE
Reduce memory usage of employee import

### DIFF
--- a/tests/views/task_test.py
+++ b/tests/views/task_test.py
@@ -36,15 +36,19 @@ class EmailLoveTestCase(LoggedInAdminBaseTest):
 class LoadEmployeesTestCase(LoggedInAdminBaseTest):
 
     @mock.patch('logic.employee.load_employees', autospec=True)
-    def test_load_employees_from_s3(self, mock_load_employees):  # noqa
+    @mock.patch('logic.love_count.rebuild_love_count', autospec=True)
+    def test_load_employees_from_s3(self, mock_load_employees, mock_rebuild_love_count):  # noqa
         response = self.app.get('/tasks/employees/load/s3')
 
         self.assertEqual(response.status_int, 200)
-        mock_load_employees.assert_called_with()
+        self.assertEqual(mock_load_employees.call_count, 1)
+        self.assertEqual(mock_rebuild_love_count.call_count, 1)
 
     @mock.patch('logic.employee.load_employees_from_csv', autospec=True)
-    def test_load_employees_from_csv(self, mock_load_employees_from_csv):  # noqa
+    @mock.patch('logic.love_count.rebuild_love_count', autospec=True)
+    def test_load_employees_from_csv(self, mock_load_employees_from_csv, mock_rebuild_love_count):  # noqa
         response = self.app.post('/tasks/employees/load/csv')
 
         self.assertEqual(response.status_int, 200)
-        mock_load_employees_from_csv.assert_called_with()
+        self.assertEqual(mock_load_employees_from_csv.call_count, 1)
+        self.assertEqual(mock_rebuild_love_count.call_count, 1)

--- a/views/tasks.py
+++ b/views/tasks.py
@@ -18,6 +18,8 @@ from models import Love
 @app.route('/tasks/employees/load/s3', methods=['GET'])
 def load_employees_from_s3():
     logic.employee.load_employees()
+    # we need to rebuild the love count index as the departments may have changed.
+    logic.love_count.rebuild_love_count()
     return Response(status=200)
 
 
@@ -25,6 +27,8 @@ def load_employees_from_s3():
 @app.route('/tasks/employees/load/csv', methods=['POST'])
 def load_employees_from_csv():
     logic.employee.load_employees_from_csv()
+    # we need to rebuild the love count index as the departments may have changed.
+    logic.love_count.rebuild_love_count()
     return Response(status=200)
 
 


### PR DESCRIPTION
We've occasionally had trouble with the employee import memory usage already, now with the rebuilding of the love count it takes over twice as much memory as before. This PR hopes to address that:

1. It fetches DB employess only once instead of twice. Additionally it removes the fetching of each individual employee from the DB as we iterate through the S3 dataset, which should make it quite a bit faster.
2. It moves rebuilding the love count out of the `_update_employees` function so the memory of the data structures used there can be freed.

Let's see if it helps. I ran it locally and it worked, but I don't know how much memory it consumed.