### PR TITLE
Reduce memory usage of employee import, fix rebuild_love_count()

### DIFF
--- a/logic/employee.py
+++ b/logic/employee.py
@@ -40,7 +40,7 @@ def load_employees_from_csv():
 def _get_employee_info_from_csv():
     logging.info('Reading employees from csv file...')
     employees = csv.DictReader(open(csv_import_file()))
-    logging.info('Done.')
+    logging.info('Done reading employees from csv file.')
     return employees
 
 
@@ -69,7 +69,7 @@ def _clear_index():
         last_id = doc_ids[-1]
         index.delete(doc_ids)
 
-    logging.info('Done. {}MB'.format(memory_usage().current()))
+    logging.info('Done clearing index. {}MB'.format(memory_usage().current()))
 
 
 def _generate_substrings(string):
@@ -95,7 +95,7 @@ def _get_employee_info_from_s3():
         'employees.json',
     )
     employee_dicts = json.loads(key.get_contents_as_string())
-    logging.info('Done. {}MB'.format(memory_usage().current()))
+    logging.info('Done reading employees file from S3. {}MB'.format(memory_usage().current()))
     return employee_dicts
 
 
@@ -122,7 +122,7 @@ def _index_employees(employees):
                 ])
                 documents.append(doc)
         index.put(documents)
-    logging.info('Done. {}MB'.format(memory_usage().current()))
+    logging.info('Done indexing employees. {}MB'.format(memory_usage().current()))
 
 
 def _update_employees(employee_dicts):
@@ -171,7 +171,7 @@ def _update_employees(employee_dicts):
         terminated_employees.append(employee)
     ndb.put_multi(terminated_employees)
 
-    logging.info('Done. {}MB'.format(memory_usage().current()))
+    logging.info('Done updating employees. {}MB'.format(memory_usage().current()))
 
 
 def combine_employees(old_username, new_username):
@@ -200,7 +200,7 @@ def combine_employees(old_username, new_username):
         love_to_save.append(received_love)
 
     ndb.put_multi(love_to_save)
-    logging.info('Done.')
+    logging.info('Done reassigning love.')
 
     # Second, we need to update the LoveCount table
     logging.info('Updating LoveCount table...')
@@ -233,12 +233,12 @@ def combine_employees(old_username, new_username):
 
     ndb.delete_multi(love_counts_to_delete)
     ndb.put_multi(love_counts_to_save)
-    logging.info('Done.')
+    logging.info('Done updating LoveCount table.')
 
     # Now we can delete the old employee
     logging.info('Deleting employee {}...'.format(old_username))
     old_employee_key.delete()
-    logging.info('Done.')
+    logging.info('Done deleting employee.')
 
     # ... Which means we need to rebuild the index
     rebuild_index()

--- a/logic/love_count.py
+++ b/logic/love_count.py
@@ -1,9 +1,13 @@
 # -*- coding: utf-8 -*-
+import datetime
 import logging
 
+from google.appengine.api.runtime import memory_usage
 from google.appengine.ext import ndb
 
+from logic import utc_week_limits
 from logic.toggle import set_toggle_state
+from models import Employee
 from models import Love
 from models import LoveCount
 from models.toggle import LOVE_SENDING_ENABLED
@@ -42,12 +46,28 @@ def top_lovers_and_lovees(utc_week_start, dept=None, limit=20):
 
 
 def rebuild_love_count():
+    utc_dt = datetime.datetime.utcnow() - datetime.timedelta(days=7)  # rebuild last week and this week
+    week_start, _ = utc_week_limits(utc_dt)
+
     set_toggle_state(LOVE_SENDING_ENABLED, False)
 
-    logging.info('Rebuilding LoveCount table...')
-    ndb.delete_multi(LoveCount.query().fetch(keys_only=True))
-    for l in Love.query().iter(batch_size=1000):
-        LoveCount.update(l)
-    logging.info('Done.')
+    logging.info('Deleting LoveCount table... {}MB'.format(memory_usage().current()))
+    ndb.delete_multi(LoveCount.query(LoveCount.week_start >= week_start).fetch(keys_only=True))
+    employee_dict = {
+        employee.key: employee
+        for employee in Employee.query()
+    }
+    logging.info('Rebuilding LoveCount table... {}MB'.format(memory_usage().current()))
+    cursor = None
+    count = 0
+    while True:
+        loves, cursor, has_more = Love.query(Love.timestamp >= week_start).fetch_page(500, start_cursor=cursor)
+        for l in loves:
+            LoveCount.update(l, employee_dict=employee_dict)
+        count += len(loves)
+        logging.info('Processed {} loves, {}MB'.format(count, memory_usage().current()))
+        if not has_more:
+            break
+    logging.info('Done. {}MB'.format(memory_usage().current()))
 
     set_toggle_state(LOVE_SENDING_ENABLED, True)

--- a/models/love_count.py
+++ b/models/love_count.py
@@ -12,7 +12,7 @@ class LoveCount(ndb.Model):
     department = ndb.StringProperty()
 
     @classmethod
-    def update(cls, love):
+    def update(cls, love, employee_dict=None):
         utc_week_start, _ = utc_week_limits(love.timestamp)
 
         sender_count = cls.query(
@@ -22,7 +22,7 @@ class LoveCount(ndb.Model):
         if sender_count is not None:
             sender_count.sent_count += 1
         else:
-            employee = love.sender_key.get()
+            employee = employee_dict[love.sender_key] if employee_dict else love.sender_key.get()
             sender_count = cls(
                 parent=love.sender_key,
                 sent_count=1,
@@ -39,7 +39,7 @@ class LoveCount(ndb.Model):
         if recipient_count is not None:
             recipient_count.received_count += 1
         else:
-            employee = love.recipient_key.get()
+            employee = employee_dict[love.recipient_key] if employee_dict else love.recipient_key.get()
             recipient_count = cls(
                 parent=love.recipient_key,
                 received_count=1,

--- a/tests/views/api_test.py
+++ b/tests/views/api_test.py
@@ -3,6 +3,8 @@ from __future__ import unicode_literals, print_function
 
 import unittest
 
+import mock
+
 import logic.employee
 import logic.love
 from models import AccessKey
@@ -53,7 +55,8 @@ class AutocompleteTest(_ApiKeyRequiredTestCase):
         create_employee(username='alex')
         create_employee(username='bob')
         create_employee(username='carol')
-        logic.employee.rebuild_index()
+        with mock.patch('logic.employee.memory_usage', autospec=True):
+            logic.employee.rebuild_index()
         self.api_key = AccessKey.create('autocomplete key').access_key
 
     def test_autocomplete(self):

--- a/tests/views/task_test.py
+++ b/tests/views/task_test.py
@@ -35,20 +35,20 @@ class EmailLoveTestCase(LoggedInAdminBaseTest):
 
 class LoadEmployeesTestCase(LoggedInAdminBaseTest):
 
+    @mock.patch('google.appengine.api.taskqueue.add', autospec=True)
     @mock.patch('logic.employee.load_employees', autospec=True)
-    @mock.patch('logic.love_count.rebuild_love_count', autospec=True)
-    def test_load_employees_from_s3(self, mock_load_employees, mock_rebuild_love_count):  # noqa
+    def test_load_employees_from_s3(self, mock_load_employees, mock_taskqueue_add):  # noqa
         response = self.app.get('/tasks/employees/load/s3')
 
         self.assertEqual(response.status_int, 200)
         self.assertEqual(mock_load_employees.call_count, 1)
-        self.assertEqual(mock_rebuild_love_count.call_count, 1)
+        mock_taskqueue_add.assert_called_once_with(url='/tasks/love_count/rebuild')
 
+    @mock.patch('google.appengine.api.taskqueue.add', autospec=True)
     @mock.patch('logic.employee.load_employees_from_csv', autospec=True)
-    @mock.patch('logic.love_count.rebuild_love_count', autospec=True)
-    def test_load_employees_from_csv(self, mock_load_employees_from_csv, mock_rebuild_love_count):  # noqa
+    def test_load_employees_from_csv(self, mock_load_employees_from_csv, mock_taskqueue_add):  # noqa
         response = self.app.post('/tasks/employees/load/csv')
 
         self.assertEqual(response.status_int, 200)
         self.assertEqual(mock_load_employees_from_csv.call_count, 1)
-        self.assertEqual(mock_rebuild_love_count.call_count, 1)
+        mock_taskqueue_add.assert_called_once_with(url='/tasks/love_count/rebuild')

--- a/tests/views/web_test.py
+++ b/tests/views/web_test.py
@@ -592,7 +592,8 @@ class AutocompleteTest(LoggedInUserBaseTest):
         create_employee(username='alex')
         create_employee(username='bob')
         create_employee(username='carol')
-        logic.employee.rebuild_index()
+        with mock.patch('logic.employee.memory_usage', autospec=True):
+            logic.employee.rebuild_index()
 
     def test_autocomplete(self):
         self._test_autocomplete('a', ['alice', 'alex'])


### PR DESCRIPTION
This PR adds a bunch of logging for memory usage using a deprecated (but functioning app engine API. It also reduces memory usage for a bunch of maintenance tasks:

- deleting and recreating indexes does so synchronously, and does not create a list of futures with _all_ of the document IDs we have
- rebuild_love_count only does so for the last two weeks now. I think this has been broken for a long time due to the size of our dataset, but we now need to run it again
- it's also passing in a dict of all employees to `LoveCount.update()`, instead of fetching them again all of the time
- `load_employees_from_s3` now enqueues a task to rebuild the love count. This not only decouples them and helps with memory usage, it also makes it more obvious that we can execute the latter separately
- I've removed the usage of `background_thread`, which is discouraged by Google and doesn't seem to give us any benefits - on the contrary, I was not able to find the logs emitted by background threads, which made debugging much harder
- The new `rebuild_love_count()` runs for about 30 minutes. This means sending love is disabled for quite a long time every day, but also means we're not running into any timout issues.