### PR TITLE
Migrate to using the Google Cloud SDK for deployment

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,6 +15,7 @@
     -   id: double-quote-string-fixer
     -   id: end-of-file-fixer
     -   id: flake8
+        language_version: python2.7
     -   id: fix-encoding-pragma
     -   id: name-tests-test
     -   id: pretty-format-json

--- a/Makefile
+++ b/Makefile
@@ -6,15 +6,9 @@ run-dev: config.py lib
 	dev_appserver.py --enable_console true --dev_appserver_log_level debug dispatch.yaml app.yaml worker.yaml
 
 deploy: deploy_build
-	# If you are running into permission issues and see a message like this:
-	# You do not have permission to modify this app (app_id=u'foobar').
-	# then try adding --no_cookies to the commands below
-	appcfg.py update app.yaml worker.yaml
-	appcfg.py update_dispatch .
-	appcfg.py update_queues .
-	appcfg.py update_indexes .
+	gcloud app deploy app.yaml worker.yaml index.yaml dispatch.yaml --no-promote
 	# If you are using cron.yaml uncomment the line below
-	# appcfg.py update_cron .
+	# gcloud app deploy cron.yaml
 
 deploy_build: config.py clean lib test
 	@echo "\033[31mHave you bumped the app version? Hit ENTER to continue, CTRL-C to abort.\033[0m"
@@ -37,5 +31,5 @@ clean:
 
 google_appengine:
 	mkdir -p tmp
-	wget -O tmp/google_appengine.zip 'https://storage.googleapis.com/appengine-sdks/featured/google_appengine_1.9.40.zip' --no-check-certificate
+	wget -O tmp/google_appengine.zip 'https://storage.googleapis.com/appengine-sdks/featured/google_appengine_1.9.88.zip' --no-check-certificate
 	unzip tmp/google_appengine.zip

--- a/README.md
+++ b/README.md
@@ -24,25 +24,15 @@ To get an idea what Yelp Love looks like go and check out the [screenshots](/scr
 
 Yelp Love runs on [Google App Engine](https://appengine.google.com/).
 In order to install Yelp Love you will need a Google account and the
-[Google App Engine SDK for Python](https://cloud.google.com/appengine/downloads).
-We recommend installing this via Homebrew if you don't already have it:
-```
-$ brew install google-app-engine
-```
+[Google App Engine SDK for Python 2.7](https://cloud.google.com/appengine/docs/standard/python/download).
 
 ### Create a new project
 
-Login to [Google Cloud Platform](https://console.cloud.google.com) and create a
-new project and give it a project name. Optionally you
-can specify a project id - a unique identifier for your project. If you don‘t
-specify a project id Google will create a random one for you. This id can not be
-changed once the project is created.
+[Follow the instructions](https://cloud.google.com/appengine/docs/standard/python/getting-started/python-standard-env)
+on creating a project and initializing your App Engine app - you'll also need
+to set up billing and give Cloud Build permission to deploy your app.
 
 ### Prepare for deployment
-
-Before you can deploy the application for the first time and start sending love
-you have to modify [app.yaml](app.yaml) and [worker.yaml](worker.yaml). Please
-edit these files and replace the application placeholder with your project id.
 
 Copy the [example config](config-example.py) file to config.py and change the
 settings. Don't forget to specify your own SECRET_KEY.
@@ -55,6 +45,14 @@ $ make deploy
 ```
 This will open a browser window for you to authenticate yourself with your
 Google account and will upload your local application code to Google App Engine.
+
+If the initial deployment fails with a Cloud Build error, try running
+```
+$ gcloud app deploy
+```
+manually. After that, `make deploy` should do the job, and will make sure
+everything is uploaded properly - including the worker service, database indexes
+and so on.
 
 Once the deployment succeeds open your browser and navigate to your application
 URL, normally [https://project_id.appspot.com](https://project_id.appspot.com).
@@ -119,19 +117,6 @@ your favorite packet manager.
 * Make your changes
 
 ## Deployment
-
-Once you've made your code changes and want to deploy them, you must bump the app version. If you don't,
-your [deployment](#initial-deployment) will overwrite the active version of the
-app on App Engine. The version number must be updated in 2 or possibly 3 places,
-depending on the nature of your changes.
-
-You will absolutely want to bump the version in [setup.py](setup.py) and
-[app.yaml](app.yaml). These versions should always match e.g., 1.3.10 in
-setup.py and 1-3-10 in app.yaml.
-
-If you modified [worker.yaml](worker.yaml) then you will also need to bump the
-version of worker.yaml. This version number is specific to the worker service and
-is independent of the main app version.
 
 When you bumped versions in the appropriate files you can deploy your changes by running
 <code>make deploy</code>.

--- a/app.yaml
+++ b/app.yaml
@@ -1,6 +1,4 @@
-application: yelplove
 service: default
-version: 1-0-0
 runtime: python27
 api_version: 1
 threadsafe: true

--- a/worker.yaml
+++ b/worker.yaml
@@ -1,6 +1,4 @@
-application: yelplove
 service: worker
-version: 1-0-0
 runtime: python27
 api_version: 1
 threadsafe: true


### PR DESCRIPTION
I deployed our internal version of Yelp Love today, and since I have a new laptop I had significant issues in doing so.

1. `brew install google-app-engine` doesn't work anymore (and is Mac-only)
2. Google's installation and setup instructions are all for the Google Cloud SDK, which does not include `appcfg.py` - which the Makefile uses to deploy our app.
3. The app engine SDK we install in the Makefile complained that it doesn't recognize the `B4_HIGHMEM` instance type.
4. My default version of Python is Python 3, so tests were failing due to the flake8 pre-commit hook complaining about Python 2 things in the code (like `xrange`).

We'll need to migrate to using the Google Cloud SDK, as it [might stop working](https://cloud.google.com/appengine/docs/standard/python/sdk-gcloud-migration) at the end of July. This will be required for the Python 3 port (#69) as well.

I manually set the app version when I deployed, but from now on it can be set automatically. No need to bump versions anymore.

I verified that uploading still works. `make test` passes too.