### PR TITLE
Use curl instead of wget, which is available on more systems

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,5 +31,5 @@ clean:
 
 google_appengine:
 	mkdir -p tmp
-	wget -O tmp/google_appengine.zip 'https://storage.googleapis.com/appengine-sdks/featured/google_appengine_1.9.88.zip' --no-check-certificate
+	curl -o tmp/google_appengine.zip 'https://storage.googleapis.com/appengine-sdks/featured/google_appengine_1.9.88.zip'
 	unzip tmp/google_appengine.zip


### PR DESCRIPTION
This allows the `google_appengine` target to be executed on macOS and Windows 10 without having to install additional software (provided you have `make`, of course).